### PR TITLE
Improve timeout for load_all

### DIFF
--- a/lib/location.ex
+++ b/lib/location.ex
@@ -6,7 +6,7 @@ defmodule Location do
   defdelegate search_subdivision(code), to: Location.Subdivision
   defdelegate get_city(code), to: Location.City
 
-  def load_all do
+  def load_all(timeout \\ 30_000) do
     me = self()
 
     Logger.debug("Loading location databases...")
@@ -15,7 +15,7 @@ defmodule Location do
       Task.async(fn -> Location.Country.load(me) end),
       Task.async(fn -> Location.Subdivision.load(me) end),
       Task.async(fn -> Location.City.load(me) end)
-    ] |> Enum.map(fn task -> Task.await(task, 30_000) end)
+    ] |> Task.await_many(timeout)
 
     Logger.debug("Location databases loaded")
   end


### PR DESCRIPTION
With the [downloaded locations](https://github.com/plausible/analytics/blob/660e5d37c9670045592493a6fdb49ca1f5191075/Dockerfile#L21), the timeout is expiring on older machines. This merge request allows for configuring the timeout for the Location.load_all function.

Also it fixes the logic for awaiting the tasks, since like this the timeout might actually be up to 90 seconds and not 30 seconds (see https://angelika.me/2021/03/13/the-problem-with-task-await-and-timeouts/)


