### PR TITLE
Speed up location db loading by ~10x

### DIFF
--- a/lib/location/city.ex
+++ b/lib/location/city.ex
@@ -1,30 +1,36 @@
 defmodule Location.City do
   @ets_table :geonames
-  @ets_table_by_label :geonames_by_label
 
   defstruct [:id, :name, :country_code]
 
-  def load(heir) do
-    :ets.new(@ets_table, [:named_table, :compressed, {:heir, heir, []}])
+  def load() do
+    @ets_table =
+      :ets.new(@ets_table, [
+        :named_table,
+        :public,
+        :compressed,
+        {:write_concurrency, true},
+        {:read_concurrency, true}
+      ])
 
-    :ets.new(@ets_table_by_label, [
-      :named_table,
-      :ordered_set,
-      {:read_concurrency, true},
-      {:heir, heir, []}
-    ])
+    source_file()
+    |> File.stream!()
+    |> Stream.chunk_every(15_000)
+    |> Task.async_stream(fn chunk ->
+      chunk
+      |> LocationCSV.parse_stream()
+      |> Stream.map(fn [id, name, country_code] ->
+        id = String.to_integer(id)
+        country_code = String.trim(country_code)
 
-    tab = :binary.compile_pattern("\t")
-
-    File.stream!(source_file())
-    |> Stream.map(&String.split(&1, tab))
-    |> Enum.each(fn [id, name, country_code] ->
-      id = String.to_integer(id)
-      country_code = String.trim(country_code)
-
-      :ets.insert(@ets_table, {id, {name, country_code}})
-      :ets.insert(@ets_table_by_label, {{name, country_code}, id})
+        {id, {name, country_code}}
+      end)
+      |> Stream.each(fn chunk ->
+        :ets.insert(@ets_table, chunk)
+      end)
+      |> Stream.run()
     end)
+    |> Stream.run()
   end
 
   @doc """
@@ -46,8 +52,13 @@ defmodule Location.City do
   """
   @spec get_city(String.t(), String.t()) :: %__MODULE__{} | nil
   def get_city(name, country_code) do
-    case :ets.lookup(@ets_table_by_label, {name, country_code}) do
-      [{{name, country_code}, id}] -> to_struct(id, name, country_code)
+    matchspec = [
+      {{:"$1", {:"$2", :"$3"}}, [{:andalso, {:==, :"$2", name}, {:==, :"$3", country_code}}],
+       [:"$1"]}
+    ]
+
+    case :ets.select(@ets_table, matchspec, 1) do
+      {[id], _} -> to_struct(id, name, country_code)
       _ -> nil
     end
   end

--- a/lib/location/country.ex
+++ b/lib/location/country.ex
@@ -3,8 +3,8 @@ defmodule Location.Country do
 
   defstruct [:alpha_2, :alpha_3, :name, :flag]
 
-  def load(heir) do
-    ets = :ets.new(@ets_table, [:named_table, {:heir, heir, []}])
+  def load() do
+    ets = :ets.new(@ets_table, [:named_table])
 
     File.read!(source_file())
     |> Jason.decode!()
@@ -28,14 +28,18 @@ defmodule Location.Country do
   def search_country(search_phrase) do
     search_phrase = String.downcase(search_phrase)
 
-    :ets.foldl(fn
-      {_code, entry}, acc ->
-        if String.contains?(String.downcase(entry.name), search_phrase) do
-          [entry | acc]
-        else
-          acc
-        end
-    end, [], @ets_table)
+    :ets.foldl(
+      fn
+        {_code, entry}, acc ->
+          if String.contains?(String.downcase(entry.name), search_phrase) do
+            [entry | acc]
+          else
+            acc
+          end
+      end,
+      [],
+      @ets_table
+    )
   end
 
   def get_country(code) do
@@ -50,7 +54,7 @@ defmodule Location.Country do
       name: entry["common_name"] || entry["name"],
       flag: entry["flag"],
       alpha_2: entry["alpha_2"],
-      alpha_3: entry["alpha_3"],
+      alpha_3: entry["alpha_3"]
     }
   end
 

--- a/lib/location/subdivision.ex
+++ b/lib/location/subdivision.ex
@@ -3,8 +3,8 @@ defmodule Location.Subdivision do
 
   defstruct [:code, :name, :type, :country_code]
 
-  def load(heir) do
-    ets = :ets.new(@ets_table, [:named_table, {:heir, heir, []}])
+  def load() do
+    ets = :ets.new(@ets_table, [:named_table])
 
     translations = File.read!(translations_file()) |> Jason.decode!()
 
@@ -26,14 +26,18 @@ defmodule Location.Subdivision do
   def search_subdivision(search_phrase) do
     search_phrase = String.downcase(search_phrase)
 
-    :ets.foldl(fn
-      {_code, entry}, acc ->
-        if String.contains?(String.downcase(entry.name), search_phrase) do
-          [entry | acc]
-        else
-          acc
-        end
-    end, [], @ets_table)
+    :ets.foldl(
+      fn
+        {_code, entry}, acc ->
+          if String.contains?(String.downcase(entry.name), search_phrase) do
+            [entry | acc]
+          else
+            acc
+          end
+      end,
+      [],
+      @ets_table
+    )
   end
 
   def get_subdivision(code) do
@@ -44,7 +48,7 @@ defmodule Location.Subdivision do
   end
 
   defp to_struct(entry) do
-    country_code = entry["code"] |> String.split("-") |> List.first
+    country_code = entry["code"] |> String.split("-") |> List.first()
 
     %__MODULE__{
       code: entry["code"],
@@ -56,7 +60,9 @@ defmodule Location.Subdivision do
 
   defp translate_entry(translations, entry) do
     case Map.get(translations, entry["code"]) do
-      nil -> entry
+      nil ->
+        entry
+
       translation ->
         Map.put(entry, "name", translation)
     end

--- a/lib/mix/tasks/update_english_translations.ex
+++ b/lib/mix/tasks/update_english_translations.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.UpdateEnglishTranslations do
 
   def run(_) do
     HTTPoison.start()
-    Location.Country.load(self())
+    Location.Country.load()
     Location.Scraper.scrape()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule Location.MixProject do
   defp deps do
     [
       {:jason, "~> 1.3"},
+      {:nimble_csv, "~> 1.1"},
       {:floki, "~> 0.31.0", only: [:dev, :test]},
       {:httpoison, "~> 1.8", only: [:dev, :test]},
       {:flow, "~> 1.0", only: [:dev, :test]}

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,7 @@
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "nimble_csv": {:hex, :nimble_csv, "1.2.0", "4e26385d260c61eba9d4412c71cea34421f296d5353f914afe3f2e71cce97722", [:mix], [], "hexpm", "d0628117fcc2148178b034044c55359b26966c6eaa8e2ce15777be3bbc91b12a"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},


### PR DESCRIPTION
This PR speeds up location db loading.

The biggest resource is the geodata csv file (~122mb), others are small. 

There is no benefit in running them all in parallel. We make the country db ets table public so max cores available are used to parse and process the input stream. No heir trickery is necessary, there is no reason to believe something else will overwrite that table. Other tables are good to go being `protected` by default. There is also no need to keep/populate two ets tables, one is sufficient with a `select` query.

On my Threadripper this reduces loading time from ~30s to ~3s.