### PR TITLE
Add country code for anonymising VPN services

### DIFF
--- a/priv/override/iso_3166-1.json
+++ b/priv/override/iso_3166-1.json
@@ -4,5 +4,10 @@
     "alpha_3": "XKX",
     "flag": "🇽🇰",
     "name": "Kosovo"
+  },
+  {
+    "alpha_2": "A1",
+    "flag": "🏳️",
+    "name": "Anonymous VPN Service"
   }
 ]


### PR DESCRIPTION
This is needed for https://github.com/plausible/analytics/pull/3766


This adds a new country code A1 to represent visitors using VPN services to mask their location.



![image](https://github.com/plausible/location/assets/22169793/8c1ae74a-e043-406e-845d-c41fbb62392c)
